### PR TITLE
server: clean up and speed up server shutdown

### DIFF
--- a/server.go
+++ b/server.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"log"
 	"net"
-	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/d2g/dhcp4"
@@ -37,8 +37,7 @@ type Server struct {
 	leasePool leasepool.LeasePool //Lease Pool Manager
 
 	//Used to Gracefully Close the Server
-	shutdownLock sync.Mutex
-	shutdown     bool
+	shutdown uint32
 	//Listeners & Response Connection.
 	connection *ipv4.PacketConn
 }
@@ -154,12 +153,6 @@ func SetRemoteAddr(a net.UDPAddr) func(*Server) error {
 	}
 }
 
-func (s *Server) shouldShutdown() bool {
-	s.shutdownLock.Lock()
-	defer s.shutdownLock.Unlock()
-	return s.shutdown
-}
-
 /*
  * Start The DHCP Server
  */
@@ -199,6 +192,13 @@ func (s *Server) ListenAndServe() error {
 
 			switch v := err.(type) {
 			case *net.OpError:
+				// If we've been signaled to shut down, ignore
+				// the "use of closed network connection" error
+				// since the connection was closed by the
+				// shutdown request
+				if s.shouldShutdown() {
+					return nil
+				}
 				if v.Timeout() {
 					goto ListenForDHCPPackets
 				}
@@ -212,7 +212,8 @@ func (s *Server) ListenAndServe() error {
 				}
 			}
 
-			log.Println("Debug: Unexpect Error from Connection Read From:" + err.Error())
+			log.Printf("Debug: Unexpect Error from Connection Read From: %v\n", err)
+			log.Printf("err type %T %#v\n", err, err)
 			return err
 		}
 
@@ -535,9 +536,12 @@ func (s *Server) GetLease(packet dhcp4.Packet) (found bool, lease leasepool.Leas
  * Shutdown The Server Gracefully
  */
 func (s *Server) Shutdown() {
-	s.shutdownLock.Lock()
-	defer s.shutdownLock.Unlock()
-	s.shutdown = true
+	atomic.StoreUint32(&s.shutdown, 1)
+	s.connection.Close()
+}
+
+func (s *Server) shouldShutdown() bool {
+	return atomic.LoadUint32(&s.shutdown) == 1
 }
 
 /*

--- a/server.go
+++ b/server.go
@@ -213,7 +213,7 @@ func (s *Server) ListenAndServe() error {
 			}
 
 			log.Printf("Debug: Unexpect Error from Connection Read From: %v\n", err)
-			log.Printf("err type %T %#v\n", err, err)
+			log.Printf("Debug: err type %T %#v\n", err, err)
 			return err
 		}
 


### PR DESCRIPTION
Instead of using a mutex and bool, just use atomic ops on a
single uint32.  Also close the connection in Shutdown() which
helps break out of the server loop a few seconds faster, if
the server is waiting on data from the socket.

@d2g