### PR TITLE
server/leasepool: differentiate leases based on Client ID in addition to MAC address

### DIFF
--- a/leasepool/lease_test.go
+++ b/leasepool/lease_test.go
@@ -23,6 +23,7 @@ func TestMarshaling(test *testing.T) {
 	if err != nil {
 		test.Error("Error Parsing Mac Address:" + err.Error())
 	}
+	startLease.ClientID = []byte("adsfasdfasf")
 
 	byteStartLease, err := json.Marshal(startLease)
 	if err != nil {

--- a/leasepool/leasepool.go
+++ b/leasepool/leasepool.go
@@ -25,8 +25,8 @@ type LeasePool interface {
 	 */
 	GetLease(net.IP) (bool, Lease, error)
 
-	//Get the lease already in use by that hardware address.
-	GetLeaseForHardwareAddress(net.HardwareAddr) (bool, Lease, error)
+	//Get the lease already in use by that hardware address and/or client identifier.
+	GetLeaseForClient(net.HardwareAddr, []byte) (bool, Lease, error)
 
 	/*
 	 * -Lease Available


### PR DESCRIPTION
To handle cases where the same interface (and thus same MAC) may request
multiple DHCP leases, assign leases based on MAC and ClientID if one is
given. This situation can arise where multiple virtual interfaces are using
the same physical interface (eg, Linux ipvlan) or where a single
interface actually does request multiple IP addresess for whatever
reason.

@d2g 